### PR TITLE
[milky] add rust-sdk into ecosystem

### DIFF
--- a/markdown/guide/ecosystem.md
+++ b/markdown/guide/ecosystem.md
@@ -11,3 +11,5 @@
 - [NoneBot](https://nonebot.dev/) - 通过 [adapter-milky](https://github.com/nonebot/adapter-milky)
 
 ## Milky SDK
+
+- Rust - [vivian-rs](https://crates.io/crates/vivian)


### PR DESCRIPTION
Add a new SDK entry to the documentation for the Rust implementation of the Milky protocol