### PR TITLE
[milky] splitting `accept_request` and `reject_request`

### DIFF
--- a/markdown/api/request.md
+++ b/markdown/api/request.md
@@ -42,7 +42,7 @@
 | --- | --- | --- |
 | invitations | Array<[GroupInvitation](../struct/GroupInvitation.md)> | 群邀请列表 |
 
-## `accept_request` 同意请求
+## `accept_friend_request` 同意好友请求
 
 ### 参数
 
@@ -53,7 +53,56 @@
 ### 返回值
 
 此 API 无返回值。
-## `reject_request` 拒绝请求
+
+## `accept_group_invite_request` 同意邀请入群请求
+
+### 参数
+
+| 字段名 | 类型 | 描述 |
+| --- | --- | --- |
+| request_id | string | 请求 ID |
+
+### 返回值
+
+此 API 无返回值。
+
+## `accept_group_join_request` 同意入群请求
+
+### 参数
+
+| 字段名 | 类型 | 描述 |
+| --- | --- | --- |
+| request_id | string | 请求 ID |
+
+### 返回值
+
+此 API 无返回值。
+
+## `reject_friend_request` 拒绝好友请求
+
+### 参数
+
+| 字段名 | 类型 | 描述 |
+| --- | --- | --- |
+| request_id | string | 请求 ID |
+
+### 返回值
+
+此 API 无返回值。
+
+## `reject_group_invite_request` 拒绝邀请入群请求
+
+### 参数
+
+| 字段名 | 类型 | 描述 |
+| --- | --- | --- |
+| request_id | string | 请求 ID |
+
+### 返回值
+
+此 API 无返回值。
+
+## `reject_group_join_request` 拒绝入群请求
 
 ### 参数
 

--- a/src/main/kotlin/org/ntqqrev/milky/api/RequestApi.kt
+++ b/src/main/kotlin/org/ntqqrev/milky/api/RequestApi.kt
@@ -41,15 +41,43 @@ val RequestApi = Category("request") {
         }
     }
 
-    api("accept_request") {
+    api("accept_friend_request") {
+        describe("同意好友请求")
+        input {
+            field("request_id", StringType, "请求 ID")
+        }
+    }
+
+    api("accept_group_invite_request") {
+        describe("同意邀请入群请求")
+        input {
+            field("request_id", StringType, "请求 ID")
+        }
+    }
+
+    api("accept_group_join_request") {
         describe("同意请求")
         input {
             field("request_id", StringType, "请求 ID")
         }
     }
 
-    api("reject_request") {
-        describe("拒绝请求")
+    api("reject_friend_request") {
+        describe("拒绝好友请求")
+        input {
+            field("request_id", StringType, "请求 ID")
+        }
+    }
+
+    api("reject_group_invite_request") {
+        describe("拒绝邀请入群请求")
+        input {
+            field("request_id", StringType, "请求 ID")
+        }
+    }
+
+    api("reject_group_join_request") {
+        describe("拒绝入群请求")
         input {
             field("request_id", StringType, "请求 ID")
             field("reason", StringType, "拒绝理由") { optional() }


### PR DESCRIPTION
## 将 `accept_request` 和 `reject_request` 拆分为
`accept_friend_request` `accept_group_invite_request` `accept_group_join_request`
以及
`reject_friend_request` `reject_group_invite_request` `reject_group_join_request`

# 为什么要这样做？

1. `好友请求` `邀请入群请求` 和 `请求入群请求` 在事件推送中是三种不同的事件，而处理这三种请求的 api 端口应当分开最为合适
2. 在协议端中，要维护一个使这三种请求 id 不重复的数据库较为困难
3. 将三种事件放在同一个 api 端口中处理会导致耦合过高，容易堆成屎山