### PR TITLE
feat(communication): 添加 Server-Sent Events (SSE) 连接方式

### DIFF
--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -20,7 +20,8 @@
   },
   "license": "CC0-1.0",
   "devDependencies": {
-    "@types/node": "^22.17.2"
+    "@types/node": "^22.17.2",
+    "eventsource-client": "^1.1.4"
   },
   "dependencies": {
     "@saltify/milky-types": "^1.0.0-draft.12",

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -17,15 +17,6 @@ export class MilkyClient {
   private disposeCore?: () => void;
 
   /**
-   * @param address The address of the Milky API server
-   * @param port The port of the Milky API server
-   * @param base The base path for the Milky API
-   * @param accessToken The access token for authentication (optional)
-   * @param useHttps Whether to use HTTPS (default: false)
-   * @deprecated Use the overload with `authority` instead. This will be removed in a future version.
-   */
-  constructor(address: string, port: number, base: string, accessToken?: string, useHttps?: boolean);
-  /**
    * @param authority The authority of the Milky API (value of `new URL('https://example.com:443/some-path').host`)
    * @param basePath The base path for the Milky API
    * @param accessToken The access token for authentication (optional)
@@ -38,26 +29,7 @@ export class MilkyClient {
     accessToken?: string,
     useTLS?: boolean,
     useSSE?: boolean
-  );
-
-  constructor(arg1: string, arg2?: number | string, arg3?: string, arg4?: string | boolean, arg5?: boolean) {
-    const { authority, basePath, accessToken, useTLS, useSSE } =
-      typeof arg2 === 'number'
-        ? {
-            authority: `${arg1}:${arg2}`,
-            basePath: arg3 ?? '/',
-            accessToken: arg4,
-            useTLS: arg5,
-            useSSE: false,
-          }
-        : {
-            authority: arg1,
-            basePath: arg2 ?? '/',
-            accessToken: arg3,
-            useTLS: !!arg4,
-            useSSE: !!arg5,
-          };
-
+  ) {
     const httpProtocol = useTLS ? 'https' : 'http';
     const urlFragment = `${authority}${basePath}`;
     const httpUrlBase = `${httpProtocol}://${urlFragment}`;
@@ -119,7 +91,7 @@ export class MilkyClient {
         Accept: 'text/event-stream',
         ...this.fetchHeader,
       },
-      onMessage: (event) => {
+      onMessage: (event: { event: string; data: string }) => {
         if (event.event !== 'milky_event') return;
 
         const data = JSON.parse(event.data);

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -1,18 +1,20 @@
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
+import { createEventSource } from 'eventsource-client';
 import type { ApiCollection, ApiResponse } from './api';
 import type { EventCollection } from './event';
 
-if (typeof globalThis.WebSocket === 'undefined') {
-  console.error('WebSocket is not supported in this environment.');
-  process.exit(1);
-}
+const combineUrl = (base: string, path: string) => {
+  const baseUrl = base.endsWith('/') ? base.slice(0, -1) : base;
+  const pathUrl = path.startsWith('/') ? path.slice(1) : path;
+  return `${baseUrl}/${pathUrl}`;
+};
 
 export class MilkyClient {
+  private readonly eventEmitter: EventEmitter;
   private readonly httpApiUrl: string;
   private readonly eventUrl: string;
-  private readonly wsClient: WebSocket;
   private readonly fetchHeader: Record<string, string>;
-  private readonly eventEmitter: EventEmitter;
+  private disposeCore?: () => void;
 
   /**
    * @param address The address of the Milky API server
@@ -20,31 +22,56 @@ export class MilkyClient {
    * @param base The base path for the Milky API
    * @param accessToken The access token for authentication (optional)
    * @param useHttps Whether to use HTTPS (default: false)
+   * @deprecated Use the overload with `authority` instead. This will be removed in a future version.
+   */
+  constructor(address: string, port: number, base: string, accessToken?: string, useHttps?: boolean);
+  /**
+   * @param authority The authority of the Milky API (value of `new URL('https://example.com:443/some-path').host`)
+   * @param basePath The base path for the Milky API
+   * @param accessToken The access token for authentication (optional)
+   * @param useTLS Whether to use HTTPS and WSS (default: false)
+   * @param useSSE Whether to use Server-Sent Events for event streaming (default: false)
    */
   constructor(
-    address: string,
-    port: number, 
-    base: string, 
-    private readonly accessToken?: string, 
-    useHttps: boolean = false
-  ) {
-    base = base.endsWith('/') ? base.slice(0, -1) : base;
-    this.httpApiUrl = `${useHttps ? 'https' : 'http'}://${address}:${port}${base}/api`;
-    this.eventUrl = accessToken
-      ? `${useHttps ? 'wss' : 'ws'}://${address}:${port}${base}/event?access_token=${accessToken}`
-      : `${useHttps ? 'wss' : 'ws'}://${address}:${port}${base}/event`;
-    this.fetchHeader = this.accessToken ? {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${this.accessToken}`,
-    } : {
-      'Content-Type': 'application/json',
-    };
-    this.wsClient = new WebSocket(this.eventUrl);
+    authority: string,
+    basePath?: `/${string}/` | '/',
+    accessToken?: string,
+    useTLS?: boolean,
+    useSSE?: boolean
+  );
+
+  constructor(arg1: string, arg2?: number | string, arg3?: string, arg4?: string | boolean, arg5?: boolean) {
+    const { authority, basePath, accessToken, useTLS, useSSE } =
+      typeof arg2 === 'number'
+        ? {
+            authority: `${arg1}:${arg2}`,
+            basePath: arg3 ?? '/',
+            accessToken: arg4,
+            useTLS: arg5,
+            useSSE: false,
+          }
+        : {
+            authority: arg1,
+            basePath: arg2 ?? '/',
+            accessToken: arg3,
+            useTLS: !!arg4,
+            useSSE: !!arg5,
+          };
+
+    const httpProtocol = useTLS ? 'https' : 'http';
+    const urlFragment = `${authority}${basePath}`;
+    const httpUrlBase = `${httpProtocol}://${urlFragment}`;
+    this.fetchHeader = {};
+    if (accessToken) this.fetchHeader['Authorization'] = `Bearer ${accessToken}`;
+
     this.eventEmitter = new EventEmitter();
-    this.wsClient.addEventListener('message', (event) => {
-      const data = JSON.parse(event.data);
-      this.eventEmitter.emit(data.event_type, data);
-    });
+    this.httpApiUrl = combineUrl(httpUrlBase, 'api');
+    this.eventUrl = combineUrl(httpUrlBase, 'api');
+    if (!useSSE) {
+      this.createWebsocket();
+    } else {
+      this.createSSE();
+    }
   }
 
   /**
@@ -57,9 +84,13 @@ export class MilkyClient {
     method: K,
     ...input: Parameters<ApiCollection[K]>
   ): Promise<ReturnType<ApiCollection[K]>> {
-    const response = await fetch(`${this.httpApiUrl}/${method}`, {
+    const response = await fetch(combineUrl(this.httpApiUrl, method), {
       method: 'POST',
-      headers: this.fetchHeader,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...this.fetchHeader,
+      },
       body: JSON.stringify(input[0] ?? {}),
     });
     const callResult = (await response.json()) as ApiResponse;
@@ -80,4 +111,49 @@ export class MilkyClient {
   ): Promise<void> {
     this.eventEmitter.on(eventType, listener);
   }
+
+  private createSSE() {
+    const sse = createEventSource({
+      url: this.eventUrl,
+      headers: {
+        Accept: 'text/event-stream',
+        ...this.fetchHeader,
+      },
+      onMessage: (event) => {
+        if (event.event !== 'milky_event') return;
+
+        const data = JSON.parse(event.data);
+        this.eventEmitter.emit(data.event_type, data);
+      },
+    });
+
+    sse.connect();
+
+    this.disposeCore = sse.close;
+  }
+
+  private createWebsocket() {
+    if (!globalThis.WebSocket) throw new Error('WebSocket is not supported in this environment.');
+
+    const ws = new WebSocket(this.eventUrl, {
+      headers: {
+        ...this.fetchHeader,
+      },
+    });
+    ws.addEventListener('message', (event) => {
+      const data = JSON.parse(event.data);
+      this.eventEmitter.emit(data.event_type, data);
+    });
+
+    this.disposeCore = ws.close;
+  }
+
+  /**
+   * Release the WebSocket / Server Sent Event connection.
+   */
+  dispose() {
+    this.disposeCore?.();
+  }
+
+  [Symbol.dispose] = this.dispose;
 }

--- a/packages/website/content/guide/communication.md
+++ b/packages/website/content/guide/communication.md
@@ -167,6 +167,10 @@ ws://{IP}:{端口}/event?access_token=123456
 }
 ```
 
+> [!tip]
+>
+> 由于 SSE 和 WebSocket 都是由 HTTP GET 请求升级而来，协议端在确定应当提供哪种连接时，应当优先检查应用端请求中的 `Upgrade` 头，如果存在且值为 `websocket`，则视为 WebSocket 连接请求，否则视为 SSE 连接请求。
+
 ### WebHook 推送
 
 以 POST 方式向给定的 WebHook 地址推送事件。POST 请求的 body 与 WebSocket 推送的格式相同。示例如下：

--- a/packages/website/content/guide/communication.md
+++ b/packages/website/content/guide/communication.md
@@ -92,12 +92,11 @@ Authorization: Bearer 123456
 
 ## 事件推送
 
-事件推送服务支持三种方式：Server-Sent Events (SSE)、 WebSocket 和 WebHook。
+事件推送服务支持三种方式：Server-Sent Events（SSE）、 WebSocket 和 WebHook。
 
-### Server-Sent Events 连接
+### SSE 连接
 
-接受路径为 `/event` 的 Http Get 请求。在成功建立连接后，协议端将会推送事件。
-为防止接口被未经授权的用户访问，协议端可以验证请求头中的 `Authorization` 字段，其格式为 `Bearer {access_token}`。
+接受路径为 `/event` 的 HTTP GET 请求，在建立连接后推送事件。为保证安全性，可以在配置文件中设置 `access_token`，协议端需要在请求头中检查 `Authorization` 字段，格式为 `Bearer {access_token}`。
 
 示例如下：
 
@@ -106,11 +105,7 @@ GET /event
 Authorization: Bearer 123456
 ```
 
-成功响应后，会收到 `Content-Type` 为 `text/event-stream` 的响应，且连接不会断开。
-
-产生事件时，此连接会接收到一条内容格式是 JSON 格式的 SSE 消息，内容格式见 [Event](https://milky.ntqqrev.org/struct/Event)。
-
-示例如下：
+协议端需要给出 `Content-Type` 为 `text/event-stream` 的响应，且一直保持连接。产生事件时，协议端会推送一条内容格式是 JSON 的 SSE 消息，内容格式见 [Event](https://milky.ntqqrev.org/struct/Event)。示例如下：
 
 ```plain
 event: milky_event

--- a/packages/website/content/guide/communication.md
+++ b/packages/website/content/guide/communication.md
@@ -92,7 +92,50 @@ Authorization: Bearer 123456
 
 ## 事件推送
 
-事件推送服务支持两种方式：WebSocket 和 WebHook。
+事件推送服务支持三种方式：Server-Sent Events (SSE)、 WebSocket 和 WebHook。
+
+### Server-Sent Events 连接
+
+接受路径为 `/event` 的 Http Get 请求。在成功建立连接后，协议端将会推送事件。
+为防止接口被未经授权的用户访问，协议端可以验证请求头中的 `Authorization` 字段，其格式为 `Bearer {access_token}`。
+
+示例如下：
+
+```http
+GET /event
+Authorization: Bearer 123456
+```
+
+成功响应后，会收到 `Content-Type` 为 `text/event-stream` 的响应，且连接不会断开。
+
+产生事件时，此连接会接收到一条内容格式是 JSON 格式的 SSE 消息，内容格式见 [Event](https://milky.ntqqrev.org/struct/Event)。
+
+示例如下：
+
+```plain
+event: milky_event
+data: {
+data:   "time": 1234567890,
+data:   "self_id": 123456789,
+data:   "event_type": "message_receive",
+data:   "data": {
+data:     "message_scene": "friend",
+data:     "peer_id": 123456789,
+data:     "message_seq": 23333,
+data:     "sender_id": 123456789,
+data:     "time": 1234567890,
+data:     "message": [
+data:       {
+data:         "type": "text",
+data:         "data": {
+data:           "text": "Hello, world!"
+data:         }
+data:       }
+data:     ]
+data:   }
+data: }
+
+```
 
 ### WebSocket 连接
 

--- a/packages/website/content/guide/communication.md
+++ b/packages/website/content/guide/communication.md
@@ -134,12 +134,11 @@ data: }
 
 ### WebSocket 连接
 
-接受路径为 `/event` 的 WebSocket 连接请求，在建立连接后推送事件。为保证安全性，可以在配置文件中设置 `access_token`，协议端需要检查连接时的 `query` 参数 `access_token`，如果不匹配则拒绝连接。
+接受路径为 `/event` 的 WebSocket 连接请求，在建立连接后推送事件。为保证安全性，可以在配置文件中设置 `access_token`，协议端需要在请求头中检查 `Authorization` 字段，格式为 `Bearer {access_token}`。
 
-例如，如果 `access_token` 配置为 `123456`，则连接 URL 为
-
+连接 URL 为
 ```
-ws://{IP}:{端口}/event?access_token=123456
+ws://{IP}:{端口}/event
 ```
 
 产生事件时，协议端会推送一条 JSON 格式的消息，格式见 [Event](../struct/Event.md)。示例如下：

--- a/packages/website/content/guide/communication.md
+++ b/packages/website/content/guide/communication.md
@@ -105,6 +105,14 @@ GET /event
 Authorization: Bearer 123456
 ```
 
+> [!tip]
+> 在不提供自定义头的应用中，应用端还可以通过 `?access_token={access_token}` 参数来提供 `access_token`。
+> 
+> 示例如下：
+> ```http
+> GET /event?access_token=123456
+> ```
+
 协议端需要给出 `Content-Type` 为 `text/event-stream` 的响应，且一直保持连接。产生事件时，协议端会推送一条内容格式是 JSON 的 SSE 消息，内容格式见 [Event](https://milky.ntqqrev.org/struct/Event)。示例如下：
 
 ```plain
@@ -140,6 +148,14 @@ data: }
 ```
 ws://{IP}:{端口}/event
 ```
+
+> [!tip]
+> 在不提供自定义头的应用中，应用端还可以通过 `?access_token={access_token}` 参数来提供 `access_token`。
+> 
+> 连接 URL 为
+> ```http
+> ws://{IP}:{端口}/event?access_token=123456
+> ```
 
 产生事件时，协议端会推送一条 JSON 格式的消息，格式见 [Event](../struct/Event.md)。示例如下：
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@types/node':
         specifier: ^22.17.2
         version: 22.17.2
+      eventsource-client:
+        specifier: ^1.1.4
+        version: 1.1.4
 
   packages/types:
     dependencies:
@@ -422,78 +425,92 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -590,36 +607,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-arm64-musl@0.1.21':
     resolution: {integrity: sha512-z2dyQmwtbpgAuUmWeJBhz00/6C3//SV0YSYE9Smfaf2DiSEEAvWyoni67pQU5/Q9FFaiyvzrCoz966EVNmz6Bg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/simple-git-linux-ppc64-gnu@0.1.21':
     resolution: {integrity: sha512-mEkVx9oQxKTdzTdjDTCc9XAaH9E9eI2F+KsY0R6DTYafgb/rwq0FJO+eCa8Llzz6ndgbLrzq4q+wHqR8z7dF3w==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-s390x-gnu@0.1.21':
     resolution: {integrity: sha512-FulRem5vdsvH0VER2Q9cynv01SugMk/jQwbytwyPziF6JZ81D6I8otP9NkS3dqv//6HCokyojH+oOnrsF82/VQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-gnu@0.1.21':
     resolution: {integrity: sha512-SY6HuLVH+IFlkz8aTf4hwtaXalqBIPyE7FvEMCQIVPf85slOHMs9RThmrL7fvuSl0EDuUKOXANUP2OtdgT+zNg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-musl@0.1.21':
     resolution: {integrity: sha512-bG6zRqlXmVysjUUXNPsApfXP6c+rSjhinmGlLh8XW6Tfj0PqYmbSTL/3XcowbP6yJGTJbbkvxmhQDdGYO99AnQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/simple-git-win32-arm64-msvc@0.1.21':
     resolution: {integrity: sha512-bTX+Xb5Fl3AYK2c8E/Pm04i29n9gP+FGNzaT7AQp0q/5Bgq1z/4jEadSmg5hXvoJOlIFN0+HZyau9gWGq7DpCQ==}
@@ -669,24 +692,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.2':
     resolution: {integrity: sha512-s6N8k8dF9YGc5T01UPQ08yxsK6fUow5gG1/axWc1HVVBYQBgOjca4oUZF7s4p+kwhkB1bDSGR8QznWrFZ/Rt5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.2':
     resolution: {integrity: sha512-o1RV/KOODQh6dM6ZRJGZbc+MOAHww33Vbs5JC9Mp1gDk8cpEO+cYC/l7rweiEalkSm5/1WGa4zY7xrNwObN4+Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.2':
     resolution: {integrity: sha512-/VUnh7w8RElYZ0IV83nUcP/J4KJ6LLYliiBIri3p3aW2giF+PAVgZb6mk8jbQSB3WlTai8gEmCAr7kptFa1H6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.2':
     resolution: {integrity: sha512-sMPyTvRcNKXseNQ/7qRfVRLa0VhR0esmQ29DD6pqvG71+JdVnESJaHPA8t7bc67KD5spP3+DOCNLhqlEI2ZgQg==}
@@ -821,56 +848,67 @@ packages:
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
@@ -1253,41 +1291,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2020,6 +2066,14 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventsource-client@1.1.4:
+    resolution: {integrity: sha512-CKnqZTwXCnHN2EqrEB9eLSjMMRqHum09VOsikkgSPoa2Jr2XgQnX7P1Fxhnnj/UHxi3GQ2xVsXDKIktEes07bg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
@@ -5719,6 +5773,12 @@ snapshots:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  eventsource-client@1.1.4:
+    dependencies:
+      eventsource-parser: 3.0.6
+
+  eventsource-parser@3.0.6: {}
 
   execa@8.0.1:
     dependencies:


### PR DESCRIPTION
close: #19 

- 新增 SSE 连接方式作为事件推送服务的第三种方式
- 详细说明 SSE 连接的建立过程和事件消息格式
- 更新文档以包含 SSE 相关的内容和示例
- 更新 node-sdk 以支持 SSE 连接
- 更新 WebSocket 关于 Token 验证部分的说明
- 更新 node-sdk 以支持使用 WebSocket 连接时，在 Authorization 中传递 Token
- 更新 node-sdk 使其兼容在 query 中塞 access_token 的验证方式