### PR TITLE
fix: correct event URL from /api to /event

### DIFF
--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -38,7 +38,7 @@ export class MilkyClient {
 
     this.eventEmitter = new EventEmitter();
     this.httpApiUrl = combineUrl(httpUrlBase, 'api');
-    this.eventUrl = combineUrl(httpUrlBase, 'api');
+    this.eventUrl = combineUrl(httpUrlBase, 'event');
     if (!useSSE) {
       this.createWebsocket();
     } else {


### PR DESCRIPTION
修改eventUrl端点从api到event后sdk可以正常连接接收消息