### PR TITLE
feat: 给合并转发的发送增加更多字段

### DIFF
--- a/types/src/message.ts
+++ b/types/src/message.ts
@@ -187,7 +187,11 @@ export const OutgoingSegment = z.discriminatedUnion('type', [
     data: z.object({
       get messages() {
         return z.array(z.lazy(() => OutgoingForwardedMessage)).describe('合并转发消息段');
-      }
+      },
+      title: ZString.nullish().describe('合并转发标题'),
+      preview: z.array(z.object({ text: ZString })).nullish().describe('合并转发预览文本'),
+      summary: ZString.nullish().describe('合并转发摘要'),
+      prompt: ZString.nullish().describe('合并转发外显文本'),
     }),
   }).describe('合并转发消息段'),
 ]).describe('发送消息段');


### PR DESCRIPTION
将接收用的 title preview summary prompt 字段添加到合并转发的发送消息段中

我曾经给 NapCat 提交过 https://github.com/NapNeko/NapCatQQ/pull/463 这个 PR，我希望这个元数据能加入 Milky 的标准